### PR TITLE
add tag for (living) language documents edited by non-native speakers

### DIFF
--- a/living/achinese.md
+++ b/living/achinese.md
@@ -34,7 +34,7 @@ Additional Information:
 - ISO-639-3 code: ace
 - https://en.wikipedia.org/wiki/ISO_639:ace
 - Acehnese is an Austronesian language spoken primarily in the Aceh province of Sumatra, Indonesia, with approximately 3.5-4 million speakers.
-- This document was edited by a non-native speaker.
+- This document needs reviewing by a native speaker.
 - 
 
 Scripts:

--- a/living/buginese.md
+++ b/living/buginese.md
@@ -37,7 +37,7 @@ Additional Information:
 - ISO-639-3 code: bug
 - https://en.wikipedia.org/wiki/ISO_639:bug
 - The Bugis language is primarily spoken by ~5 million people, mainly in South Sulawesi, Indonesia, with communities also present in Malaysia and Singapore.
-- This document was edited by a non-native speaker.
+- This document needs reviewing by a native speaker.
 - 
 
 Scripts:

--- a/living/chokwe.md
+++ b/living/chokwe.md
@@ -45,7 +45,7 @@ Additional Information:
 - Chokwe is officially recognized as a national language in Angola, where it serves as a lingua franca in the eastern regions of the country. However, Angola's official government portal (governo.gov.ao) and ministry websites are in Portuguese, as the government conducts most of its business in Portuguese. 
 - French is the official language in the DRC, and four indigenous languages have national status (Lingala, Swahili, Kikongo, Tshiluba). Chokwe, while spoken by a community in southern DRC, is not an official language.
 - English is the official language of Zambia, and certain Bantu languages (Bemba, Nyanja, Tonga, Lozi, Lunda, Luvale, Kaonde) are used in education and some provincial administration. Chokwe is not one of these seven regional languages, although it is spoken by a minority in the northwest.
-- This document was edited by a non-native speaker.
+- This document needs reviewing by a native speaker.
 - 
 
 Scripts:

--- a/living/cornish.md
+++ b/living/cornish.md
@@ -46,7 +46,7 @@ Additional Information:
 - ISO-639-3 code: cor
 - ISO-639-1 code: kw
 - https://en.wikipedia.org/wiki/ISO_639:cor
-- This document was edited by a non-native speaker.
+- This document needs reviewing by a native speaker.
 - 
 
 Scripts:

--- a/living/icelandic.md
+++ b/living/icelandic.md
@@ -89,7 +89,7 @@ Additional Information:
 - ISO-639-2/B code: ice
 - ISO-639-3 code: isl
 - https://en.wikipedia.org/wiki/ISO_639:isl
-- This document was edited by a non-native speaker.
+- This document needs reviewing by a native speaker.
 - 
 
 

--- a/living/uighur.md
+++ b/living/uighur.md
@@ -44,7 +44,7 @@ Informative links (in English):
 Additional Information:
 - ISO-639-3 code: uig
 - https://en.wikipedia.org/wiki/ISO_639:uig
-- This document was edited by a non-native speaker.
+- This document needs reviewing by a native speaker.
 - 
 
 

--- a/living/welsh.md
+++ b/living/welsh.md
@@ -44,7 +44,7 @@ Additional Information:
 - ISO-639-3 code: cym
 - https://en.wikipedia.org/wiki/ISO_639:cym
 - Internet TLD: .cymru
-- This document was edited by a non-native speaker.
+- This document needs reviewing by a native speaker.
 - 
 
 Scripts:


### PR DESCRIPTION
This PR introduces the following tag to the "Additional Information" section in some (living) language documents, by request:

- This document needs reviewing by a native speaker.