### PR TITLE
add: second-level māori.nz domain to maori.md

### DIFF
--- a/living/maori.md
+++ b/living/maori.md
@@ -33,7 +33,8 @@ Informative links (in English):
 Additional Information:
 - ISO-639-3 code: mri
 - https://en.wikipedia.org/wiki/ISO_639:mri
-
+- Internet SLD: .maori.nz / .māori.nz
+- This document needs reviewing by a native speaker.
 
 Scripts:
 - <a href="https://en.wikipedia.org/wiki/ISO_15924">ISO 15924 Latn</a> Latin


### PR DESCRIPTION
The māori.nz second-level domain is for websites related to Māori people and culture.