### PR TITLE
Add links for yue

### DIFF
--- a/living/yue_chinese.md
+++ b/living/yue_chinese.md
@@ -32,8 +32,8 @@ Informative links (in English):
 - https://en.wikipedia.org/wiki/Cantonese
 - https://en.wikipedia.org/wiki/Written_Cantonese
 
-Additional Information:
-Formal writing almost always uses Standard Written Chinese, even when the spoken language is Cantonese. This keeps government, political, and news text uniform and widely intelligible, leaving genuine written Cantonese mostly to informal media and user-generated content.
+## Additional Information
+Formal writing almost always uses Standard Written Chinese, even when the spoken language is Cantonese. This leaves genuine written Cantonese mostly to informal media and user-generated content.
 
 ISO-639-3 code: 
 - yue

--- a/living/yue_chinese.md
+++ b/living/yue_chinese.md
@@ -42,28 +42,59 @@ Scripts:
 - ISO 15924 Hant
 - ISO 15924 Hans
 
-Instructions
-There are 2 ways to add to this document. If you aren't very familiar with Github, you can copy the entire document into an email, fill it out, and send it to web-languages ZAT commoncrawl ZOT org. We'll do the rest.
+Thank you to these people who have helped create this document:
+- 
+- 
 
-If you are familiar with Github, and are logged in, click on the pen icon in the upper right corner to start editing the document. Github will request that you fork the repo. Do that, edit the document, and finally create a pull request.
+## Instructions
 
-To see a partially completed example, look at the Welsh entry.
+There are 2 ways to add to this document. If you aren't very familiar
+with Github, you can copy the entire document into an email, fill it
+out, and send it to web-languages ZAT commoncrawl ZOT org. We'll do the rest.
 
-Sometimes asking a Large Language Model can be helpful: "What are some top websites written in the Welsh language?"
+If you are familiar with Github, and are logged in, click on the pen
+icon in the upper right corner to start editing the document.
+Github will request that you fork the repo. Do that, edit the
+document, and finally create a pull request.
 
-What kind of websites are you looking for?
-If you look at the template, we have requested urls in a few categories: News, Culture/History, Government, Political Parties, and Other. Remember that we're looking for websites in this particular language. If the language is only a part of the website, and that's visible in the URL as https://example.com/catalan/, then that's the URL you should add.
+To see a partially completed example, look at the
+[Welsh](../living/welsh.md) entry.
 
-For a language like Hindi, with 500 million speakers, there are a lot of websites to choose from. Please suggest websites that are important and influential, and please think about diversity. Are all geographic regions represented?
+Sometimes asking a Large Language Model can be helpful: "What are some
+top websites written in the Welsh language?"
 
-For a country-wide language like Hungarian, there are still probably a wide variety of websites to choose from. If a website is all English, however, that's not what we're looking for.
+## What kind of websites are you looking for?
 
-For a regional language like Catalan, things are trickier. Catalan has multiple names -- it's called Valencian in some parts of Spain -- and use of the Catalan language is a part of a vigorous debate in Spanish national and regional politics. You might not be able to find Catalan-language content for every political party, and government websites might offer Catalan content one day and remove it after the next election. In that case, please do the best you can.
+If you look at the template, we have requested urls in a few
+categories: News, Culture/History, Government, Political Parties, and
+Other. Remember that we're looking for websites in this particular
+language. If the language is only a part of the website, and that's
+visible in the URL as https://example.com/catalan/, then that's the
+URL you should add.
 
-If your favorite language has its own Wikipedia -- check the list here -- please include this link under "Other".
+For a language like Hindi, with 500 million speakers, there are a lot
+of websites to choose from. Please suggest websites that are important
+and influential, and please think about diversity. Are all geographic
+regions represented?
 
-License
-This work is marked with CC0 1.0
+For a country-wide language like Hungarian, there are still probably a
+wide variety of websites to choose from. If a website is all English,
+however, that's not what we're looking for.
+
+For a regional language like Catalan, things are trickier. Catalan has
+multiple names -- it's called Valencian in some parts of Spain -- and
+use of the Catalan language is a part of a vigorous debate in Spanish
+national and regional politics. You might not be able to find
+Catalan-language content for every political party, and government
+websites might offer Catalan content one day and remove it after
+the next election. In that case, please do the best you can.
+
+If your favorite language has its own Wikipedia -- [check the list here](https://en.wikipedia.org/wiki/List_of_Wikipedias) --
+please include this link under "Other".
+
+## License
+
+<p xmlns:cc="http://creativecommons.org/ns#" >This work is marked with <a href="https://creativecommons.org/publicdomain/zero/1.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">CC0 1.0<img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1" alt=""><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/zero.svg?ref=chooser-v1" alt=""></a></p>
 
 By editing this file, contributers are agreeing to release their contributions under the CC0 license.
 

--- a/living/yue_chinese.md
+++ b/living/yue_chinese.md
@@ -1,4 +1,4 @@
-Web Language: Cantonese (Yue)
+# Web Language: Yue Chinese
 
 Additional names:
 - 粵語
@@ -10,37 +10,44 @@ Additional names:
 - Cantonese
 - Yue Chinese
 
-Infotainment:
-- https://www.tvmost.com.hk/articles
+News:
+- 
+- 
 
-Dictionaries:
-- https://words.hk/ (粵典)
+Culture / History:
+- 
+- 
 
-Blogs:
-- https://martinoei.com/
-- https://legalteahouse.com.hk/allposts/
+Government:
+- 
+- 
 
-Forums：
-- https://lihkg.com/ (LIHKG)
-- https://www.discuss.com.hk/ (The Hong Kong Discuss Forum)
-- https://www.baby-kingdom.com/forum.php （Baby Kingdom)
+Political Parties:
+- 
+-
 
-Food reviews:
-- https://www.openrice.com/zh/hongkong
+Others:
+- https://zh-yue.wikipedia.org
+- https://www.tvmost.com.hk/articles (Infotainment)
+- https://words.hk/ (Dictionary)
+- https://martinoei.com/ (Blog)
+- https://legalteahouse.com.hk/allposts/ (Blog)
+- https://lihkg.com/ (Forum)
+- https://www.discuss.com.hk/ (Forum)
+- https://www.baby-kingdom.com/forum.php (Forum)
+- https://www.openrice.com/zh/hongkong (Food Reviews)
 
 Informative links (in English):
 - https://en.wikipedia.org/wiki/Cantonese
 - https://en.wikipedia.org/wiki/Written_Cantonese
 
-## Additional Information
-Formal writing almost always uses Standard Written Chinese, even when the spoken language is Cantonese. This leaves genuine written Cantonese mostly to informal media and user-generated content.
-
-ISO-639-3 code: 
-- yue
+Additional Information:
+- ISO-639-3 code: yue
+- Formal writing almost always uses Standard Written Chinese, even when the spoken language is Cantonese. This leaves genuine written Cantonese mostly to informal media and user-generated content.
 
 Scripts:
-- ISO 15924 Hant
-- ISO 15924 Hans
+- <a href="https://en.wikipedia.org/wiki/ISO_15924">ISO 15924 Hant</a> Hant
+- <a href="https://en.wikipedia.org/wiki/ISO_15924">ISO 15924 Hans</a> Hans
 
 Thank you to these people who have helped create this document:
 - 

--- a/living/yue_chinese.md
+++ b/living/yue_chinese.md
@@ -1,46 +1,46 @@
 Web Language: Cantonese (Yue)
 
 Additional names:
-粵語
-粤语
-廣東話
-广东话
-廣州話
-广州话
-Cantonese
-Yue Chinese
+- 粵語
+- 粤语
+- 廣東話
+- 广东话
+- 廣州話
+- 广州话
+- Cantonese
+- Yue Chinese
 
 Infotainment:
-https://www.tvmost.com.hk/articles
+- https://www.tvmost.com.hk/articles
 
 Dictionaries:
-https://words.hk/ (粵典)
+- https://words.hk/ (粵典)
 
 Blogs:
-https://martinoei.com/
-https://legalteahouse.com.hk/allposts/
+- https://martinoei.com/
+- https://legalteahouse.com.hk/allposts/
 
 Forums：
-https://lihkg.com/ (LIHKG)
-https://www.discuss.com.hk/ (The Hong Kong Discuss Forum)
-https://www.baby-kingdom.com/forum.php （Baby Kingdom)
+- https://lihkg.com/ (LIHKG)
+- https://www.discuss.com.hk/ (The Hong Kong Discuss Forum)
+- https://www.baby-kingdom.com/forum.php （Baby Kingdom)
 
 Food reviews:
-https://www.openrice.com/zh/hongkong
+- https://www.openrice.com/zh/hongkong
 
 Informative links (in English):
-https://en.wikipedia.org/wiki/Cantonese
-https://en.wikipedia.org/wiki/Written_Cantonese
+- https://en.wikipedia.org/wiki/Cantonese
+- https://en.wikipedia.org/wiki/Written_Cantonese
 
 Additional Information:
 Formal writing almost always uses Standard Written Chinese, even when the spoken language is Cantonese. This keeps government, political, and news text uniform and widely intelligible, leaving genuine written Cantonese mostly to informal media and user-generated content.
 
 ISO-639-3 code: 
-yue
+- yue
 
 Scripts:
-ISO 15924 Hant
-ISO 15924 Hans
+- ISO 15924 Hant
+- ISO 15924 Hans
 
 Instructions
 There are 2 ways to add to this document. If you aren't very familiar with Github, you can copy the entire document into an email, fill it out, and send it to web-languages ZAT commoncrawl ZOT org. We'll do the rest.

--- a/living/yue_chinese.md
+++ b/living/yue_chinese.md
@@ -1,96 +1,69 @@
-# Web Language: Yue Chinese
+Web Language: Cantonese (Yue)
 
 Additional names:
-- Cantonese
-- 粵語
-- 
+粵語
+粤语
+廣東話
+广东话
+廣州話
+广州话
+Cantonese
+Yue Chinese
 
-News:
-- 
-- 
+Infotainment:
+https://www.tvmost.com.hk/articles
 
-Culture / History:
-- 
-- 
+Dictionaries:
+https://words.hk/ (粵典)
 
-Government:
-- 
-- 
+Blogs:
+https://martinoei.com/
+https://legalteahouse.com.hk/allposts/
 
-Political Parties:
-- 
-- 
+Forums：
+https://lihkg.com/ (LIHKG)
+https://www.discuss.com.hk/ (The Hong Kong Discuss Forum)
+https://www.baby-kingdom.com/forum.php （Baby Kingdom)
 
-Other:
-- https://zh-yue.wikipedia.org
-- 
-- 
+Food reviews:
+https://www.openrice.com/zh/hongkong
 
 Informative links (in English):
-- 
-- 
+https://en.wikipedia.org/wiki/Cantonese
+https://en.wikipedia.org/wiki/Written_Cantonese
 
 Additional Information:
-- ISO-639-3 code: yue
-- https://en.wikipedia.org/wiki/ISO_639:yue
+Formal writing almost always uses Standard Written Chinese, even when the spoken language is Cantonese. This keeps government, political, and news text uniform and widely intelligible, leaving genuine written Cantonese mostly to informal media and user-generated content.
 
+ISO-639-3 code: 
+yue
 
 Scripts:
-- <a href="https://en.wikipedia.org/wiki/ISO_15924">ISO 15924 Hant</a> Hant
-- 
+ISO 15924 Hant
+ISO 15924 Hans
 
-Thank you to these people who have helped create this document:
-- 
-- 
+Instructions
+There are 2 ways to add to this document. If you aren't very familiar with Github, you can copy the entire document into an email, fill it out, and send it to web-languages ZAT commoncrawl ZOT org. We'll do the rest.
 
-## Instructions
+If you are familiar with Github, and are logged in, click on the pen icon in the upper right corner to start editing the document. Github will request that you fork the repo. Do that, edit the document, and finally create a pull request.
 
-There are 2 ways to add to this document. If you aren't very familiar
-with Github, you can copy the entire document into an email, fill it
-out, and send it to web-languages ZAT commoncrawl ZOT org. We'll do the rest.
+To see a partially completed example, look at the Welsh entry.
 
-If you are familiar with Github, and are logged in, click on the pen
-icon in the upper right corner to start editing the document.
-Github will request that you fork the repo. Do that, edit the
-document, and finally create a pull request.
+Sometimes asking a Large Language Model can be helpful: "What are some top websites written in the Welsh language?"
 
-To see a partially completed example, look at the
-[Welsh](../living/welsh.md) entry.
+What kind of websites are you looking for?
+If you look at the template, we have requested urls in a few categories: News, Culture/History, Government, Political Parties, and Other. Remember that we're looking for websites in this particular language. If the language is only a part of the website, and that's visible in the URL as https://example.com/catalan/, then that's the URL you should add.
 
-Sometimes asking a Large Language Model can be helpful: "What are some
-top websites written in the Welsh language?"
+For a language like Hindi, with 500 million speakers, there are a lot of websites to choose from. Please suggest websites that are important and influential, and please think about diversity. Are all geographic regions represented?
 
-## What kind of websites are you looking for?
+For a country-wide language like Hungarian, there are still probably a wide variety of websites to choose from. If a website is all English, however, that's not what we're looking for.
 
-If you look at the template, we have requested urls in a few
-categories: News, Culture/History, Government, Political Parties, and
-Other. Remember that we're looking for websites in this particular
-language. If the language is only a part of the website, and that's
-visible in the URL as https://example.com/catalan/, then that's the
-URL you should add.
+For a regional language like Catalan, things are trickier. Catalan has multiple names -- it's called Valencian in some parts of Spain -- and use of the Catalan language is a part of a vigorous debate in Spanish national and regional politics. You might not be able to find Catalan-language content for every political party, and government websites might offer Catalan content one day and remove it after the next election. In that case, please do the best you can.
 
-For a language like Hindi, with 500 million speakers, there are a lot
-of websites to choose from. Please suggest websites that are important
-and influential, and please think about diversity. Are all geographic
-regions represented?
+If your favorite language has its own Wikipedia -- check the list here -- please include this link under "Other".
 
-For a country-wide language like Hungarian, there are still probably a
-wide variety of websites to choose from. If a website is all English,
-however, that's not what we're looking for.
-
-For a regional language like Catalan, things are trickier. Catalan has
-multiple names -- it's called Valencian in some parts of Spain -- and
-use of the Catalan language is a part of a vigorous debate in Spanish
-national and regional politics. You might not be able to find
-Catalan-language content for every political party, and government
-websites might offer Catalan content one day and remove it after
-the next election. In that case, please do the best you can.
-
-If your favorite language has its own Wikipedia -- [check the list here](https://en.wikipedia.org/wiki/List_of_Wikipedias) --
-please include this link under "Other".
-
-## License
-
-<p xmlns:cc="http://creativecommons.org/ns#" >This work is marked with <a href="https://creativecommons.org/publicdomain/zero/1.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">CC0 1.0<img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1" alt=""><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/zero.svg?ref=chooser-v1" alt=""></a></p>
+License
+This work is marked with CC0 1.0
 
 By editing this file, contributers are agreeing to release their contributions under the CC0 license.
+


### PR DESCRIPTION
As mentioned in the additional information section.

Formal writing almost always uses Standard Written Chinese, even when the spoken language is Cantonese. This leaves genuine written Cantonese mostly to informal media and user-generated content.

therefore it is very hard for me to find links for the categories the template suggested. 
The majority of cantonese can be found in social media and forums instead.