### PR TITLE
Include link to Romanian language dictionaries

### DIFF
--- a/living/romanian.md
+++ b/living/romanian.md
@@ -51,7 +51,7 @@ Political Parties:
 
 Other:
 - https://ro.wikipedia.org
-- 
+- https://dexonline.ro (Dictionaries of the Romanian language)
 - 
 
 Informative links (in English):


### PR DESCRIPTION
Add a link to dexonline.ro for Romanian dictionaries.