### PR TITLE
Add Russian and Mandarin academic research seeds

### DIFF
--- a/living/mandarin_chinese.md
+++ b/living/mandarin_chinese.md
@@ -59,7 +59,7 @@ Political Parties:
 
 Other:
 - https://zh.wikipedia.org/wiki/Wikipedia:%E9%A6%96%E9%A1%B5
-- 
+- https://aogavrilov.com/zh/ (Simplified-Chinese machine-learning research articles and guides)
 
 Informative links (in English):
 - https://en.wikipedia.org/wiki/China

--- a/living/russian.md
+++ b/living/russian.md
@@ -53,7 +53,7 @@ Political Parties:
 
 Other:
 - https://ru.wikipedia.org
-- 
+- https://aogavrilov.com/ru/ (Russian-language machine-learning research articles and guides)
 - 
 
 Informative links (in English):


### PR DESCRIPTION
Adds one language-specific seed URL for each localized section:

- `https://aogavrilov.com/ru/` — Russian-language machine-learning research articles and guides
- `https://aogavrilov.com/zh/` — Simplified-Chinese machine-learning research articles and guides

Both URLs return static HTML without requiring JavaScript, declare the matching HTML language (`ru` and `zh-Hans`), and link to the complete localized publication and research-guide sections. The language is visible in each URL as requested by the repository guidelines.

By submitting these entries, I agree to release the contribution under the repository's CC0 terms.