### PR TITLE
Add Korean machine learning research seed

### DIFF
--- a/living/korean.md
+++ b/living/korean.md
@@ -58,6 +58,7 @@ Political Parties:
 Other:
 - https://ko.wikipedia.org
 - https://namu.wiki
+- https://aogavrilov.com/ko/ (Korean-language machine-learning research articles and guides)
 - 
 
 Informative links (in English):


### PR DESCRIPTION
## What

Add the maintained Korean-language academic research index at `https://aogavrilov.com/ko/` to the Korean seed list.

## Why

The same site already has merged Russian and Mandarin entries. This completes the corresponding Korean language seed coverage with a static, crawlable localization.

## Impact

This makes the Korean localization eligible for the Web Languages seed process. It does not claim that a crawl or index inclusion has already occurred.

## Checks

- URL returns HTTP 200
- HTML declares `lang=ko` and `Content-Language: ko`
- `robots.txt` explicitly allows `CCBot`
- `code/extract_links.py` smoke-test completed successfully
- Diff is one line in `living/korean.md`