### PR TITLE
Add Ancient Greek (grc) seed URLs (Eulogikon HTML)

### DIFF
--- a/historical/ancient_greek_to_1453_.md
+++ b/historical/ancient_greek_to_1453_.md
@@ -10,13 +10,13 @@ News:
 - 
 
 Culture / History:
-- https://eulogikon.org/works/homer-iliad-abe-ac (Eulogikon — Homer, Iliad; public-domain Ancient Greek HTML)
-- https://eulogikon.org/works/homer-odyssey-abe-ab (Eulogikon — Homer, Odyssey)
-- https://eulogikon.org/works/plato-apology-ffk-aa (Eulogikon — Plato, Apology)
-- https://eulogikon.org/works/plato-republic-ffk-ag (Eulogikon — Plato, Republic)
-- https://eulogikon.org/works/hippocrates-seed-nature-child-diseases-bww-aa (Eulogikon — Hippocratic corpus sample)
-- https://www.perseus.tufts.edu/hopper/collection?collection=Perseus:collection:Greco-Roman (Perseus Greco-Roman collection)
-- https://scaife.perseus.org/library/ (Scaife Viewer library)
+- https://eulogikon.org/works/theophrastus-eresus-enquiry-plants-ljk-ag (Eulogikon — Theophrastus, Enquiry into Plants; public-domain Ancient Greek HTML)
+- https://eulogikon.org/works/theophrastus-eresus-causes-plants-ljk-ad (Eulogikon — Theophrastus, On the Causes of Plants)
+- https://eulogikon.org/works/nemesius-emesa-nature-man-sxe-aa (Eulogikon — Nemesius, On the Nature of Man)
+- https://eulogikon.org/works/soranus-ephesus-four-books-women-omy-ac (Eulogikon — Soranus, Four Books on Women)
+- https://eulogikon.org/works/iamblichus-chalcis-mysteries-udw-ae (Eulogikon — Iamblichus, On the Mysteries)
+- https://eulogikon.org/works/heraclitus-ephesus-allegories-homeric-bko-aa (Eulogikon — Heraclitus the Allegorist, Homeric Questions)
+- https://eulogikon.org/works/alciphron-sea-letters-quo-aa (Eulogikon — Alciphron, Fishermen's Sea Letters)
 
 Government:
 - 
@@ -27,18 +27,19 @@ Political Parties:
 - 
 
 Other:
-- https://el.wikisource.org/wiki/%CE%9A%CF%8D%CF%81%CE%B9%CE%B1_%CE%A3%CE%B5%CE%BB%CE%AF%CE%B4%CE%B1 (Greek Wikisource — includes classical texts)
+- 
 - 
 
 Informative links (in English):
 - https://en.wikipedia.org/wiki/Ancient_Greek
 - https://en.wikipedia.org/wiki/ISO_639:grc
 - https://eulogikon.org/ (Eulogikon — free digital library of Ancient Greek texts)
-- https://www.perseus.tufts.edu/hopper/
 
 Additional Information:
 - ISO-639-3 code: grc
 - https://en.wikipedia.org/wiki/ISO_639:grc
+- Seeds are Eulogikon work-page HTML only (readable Ancient Greek body text). This submission does not include Perseus Hopper pages, Scaife Viewer, or Perseus/Open Greek and Latin CTS TEI XML — Common Crawl wants crawlable HTML language surfaces, not TEI corpora.
+- Seed works were chosen as distinctive material not already served as Greek HTML on classic Perseus Hopper, with clean Greek bodies (no Latin/German editorial apparatus), and Greek-dense pages suitable for language identification. Compilations and ubiquitous school texts are omitted; Eulogikon's sitemap covers broader discovery.
 - Eulogikon pages use English UI chrome with Ancient Greek body text (HTML).
 
 Scripts:

--- a/historical/ancient_greek_to_1453_.md
+++ b/historical/ancient_greek_to_1453_.md
@@ -1,15 +1,22 @@
 # Web Language: Ancient Greek (to 1453)
 
 Additional names:
-- 
+- Classical Greek
+- Ancient Greek
+- Ἀρχαία ἑλληνική
 
 News:
 - 
 - 
 
 Culture / History:
-- 
-- 
+- https://eulogikon.org/works/homer-iliad-abe-ac (Eulogikon — Homer, Iliad; public-domain Ancient Greek HTML)
+- https://eulogikon.org/works/homer-odyssey-abe-ab (Eulogikon — Homer, Odyssey)
+- https://eulogikon.org/works/plato-apology-ffk-aa (Eulogikon — Plato, Apology)
+- https://eulogikon.org/works/plato-republic-ffk-ag (Eulogikon — Plato, Republic)
+- https://eulogikon.org/works/hippocrates-seed-nature-child-diseases-bww-aa (Eulogikon — Hippocratic corpus sample)
+- https://www.perseus.tufts.edu/hopper/collection?collection=Perseus:collection:Greco-Roman (Perseus Greco-Roman collection)
+- https://scaife.perseus.org/library/ (Scaife Viewer library)
 
 Government:
 - 
@@ -20,24 +27,25 @@ Political Parties:
 - 
 
 Other:
-- 
+- https://el.wikisource.org/wiki/%CE%9A%CF%8D%CF%81%CE%B9%CE%B1_%CE%A3%CE%B5%CE%BB%CE%AF%CE%B4%CE%B1 (Greek Wikisource — includes classical texts)
 - 
 
 Informative links (in English):
-- 
-- 
+- https://en.wikipedia.org/wiki/Ancient_Greek
+- https://en.wikipedia.org/wiki/ISO_639:grc
+- https://eulogikon.org/ (Eulogikon — free digital library of Ancient Greek texts)
+- https://www.perseus.tufts.edu/hopper/
 
 Additional Information:
 - ISO-639-3 code: grc
 - https://en.wikipedia.org/wiki/ISO_639:grc
-
+- Eulogikon pages use English UI chrome with Ancient Greek body text (HTML).
 
 Scripts:
-- 
+- ISO 15924 Grek Greek
 
 Thank you to these people who have helped create this document:
-- 
-- 
+- [MouronRoger](https://github.com/MouronRoger)
 
 ## Instructions
 


### PR DESCRIPTION
## What

Fill the empty `historical/ancient_greek_to_1453_.md` template with crawlable **HTML** seed URLs for Ancient Greek (ISO-639-3: `grc`).

**Culture / History — seven Eulogikon work pages only**
- Theophrastus, *Enquiry into Plants*
- Theophrastus, *On the Causes of Plants*
- Nemesius, *On the Nature of Man*
- Soranus, *Four Books on Women*
- Iamblichus, *On the Mysteries*
- Heraclitus the Allegorist, *Homeric Questions*
- Alciphron, *Fishermen's Sea Letters*

These are public-domain Ancient Greek HTML pages at [eulogikon.org](https://eulogikon.org/).

## What this is not

- **Not** Perseus Hopper collection pages
- **Not** Scaife Viewer
- **Not** Perseus / Open Greek and Latin **CTS TEI XML** (or any TEI dump) — Common Crawl's web-languages effort needs crawlable HTML language surfaces; TEI corpora are a different channel and we are not taking credit for them here
- **Not** ubiquitous school texts already dense on the open web (Homer, Plato, etc.)
- **Not** compilations / lexica / apparatus-heavy reconstructive editions

## Why these seeds

The Ancient Greek historical entry was still a blank template. Seeds are meant for discovery (sitemap already advertised in Eulogikon `robots.txt`), so this lists a small diversified set of **distinctive, Greek-dense HTML** that classic Perseus Hopper does not already serve as Greek HTML, with clean Greek bodies (no Latin/German editorial apparatus in the text).

## Checks

- [x] Each Culture/History URL returns HTTP 200
- [x] Pages are Greek-dense HTML (body Ancient Greek; English chrome only)
- [x] Canonical text for these works has no Latin/German apparatus pollution
- [x] Eulogikon `robots.txt` allows crawling (`User-agent: *` / `Allow: /`)
- [x] `extract_links.py` accepts all 7 seed URLs (informative/English links correctly excluded)
- [x] Diff touches only `historical/ancient_greek_to_1453_.md`
- [x] Contribution released under the repository CC0 terms

## Note

Eulogikon work pages declare `html lang="en"` (English chrome) while the transmitted text is Ancient Greek. CLD2 runs on HTML content; we listed Greek-dense work pages rather than the English homepage for that reason.

Made with [Cursor](https://cursor.com)