### PR TITLE
Expand Albanian web language sources for Albania and Kosovo

### DIFF
--- a/living/albanian.md
+++ b/living/albanian.md
@@ -2,176 +2,125 @@
 
 Additional names:
 
-* shqip
-* gjuha shqipe
-* Albanian language
+- shqip
+- gjuha shqipe
+- Albanian language
 
 News:
 
-* https://top-channel.tv/ (Top Channel)
-* https://tvklan.al/ (TV Klan)
-* https://www.panorama.com.al/ (Panorama)
-* https://shqiptarja.com/ (Shqiptarja)
-* https://balkanweb.com/ (BalkanWeb)
-* https://www.gazetatema.net/ (Gazeta Tema)
-* https://www.oranews.tv/ (Ora News)
-* https://lapsi.al/ (Analysis and investigative journalism)
-* https://www.newsbomb.al/ (News)
-* https://ata.gov.al/ (Albanian Telegraphic Agency)
-* https://sq.wikipedia.org/ (Albanian Wikipedia)
-* https://rtklive.com/ (Radio Television of Kosovo)
-* https://kallxo.com/ (Investigative journalism and news)
-* https://telegrafi.com/ (Albanian-language news)
-* https://koha.net/ (Albanian-language news, culture and archive)
-* https://gazetaexpress.com/ (Albanian-language news)
-* https://insajderi.org/ (Investigative journalism)
-* https://zeri.info/ (Albanian-language news)
-* https://kosovapress.com/ (Kosovo Press)
-* https://ekonomiaonline.com/ (Economy and news)
+- https://top-channel.tv/ (Top Channel)
+- https://tvklan.al/ (TV Klan)
+- https://www.panorama.com.al/ (Panorama)
+- https://shqiptarja.com/ (Shqiptarja)
+- https://balkanweb.com/ (BalkanWeb)
+- https://www.gazetatema.net/ (Gazeta Tema)
+- https://www.oranews.tv/ (Ora News)
+- https://lapsi.al/ (Analysis and investigative journalism)
+- https://www.newsbomb.al/ (News)
+- https://ata.gov.al/ (National Broadcaster)
+- https://rtklive.com/ (Radio Television of Kosovo)
+- https://kallxo.com/ (Investigative journalism and news)
+- https://telegrafi.com/ (Albanian-language news)
+- https://koha.net/ (Albanian-language news and culture)
+- https://gazetaexpress.com/ (Albanian-language news)
+- https://kosovapress.com/ (Kosovo Press)
+- https://zeri.info/ (Albanian-language news)
+- https://insajderi.org/ (Investigative journalism)
 
 Culture / History:
 
-* https://sq.wikipedia.org/wiki/Kultura_e_Shqip%C3%ABris%C3%AB
-* https://sq.wikipedia.org/wiki/Historia_e_Shqip%C3%ABris%C3%AB
-* https://akad.gov.al/ (Academy of Sciences of Albania)
-* https://bksh.al/ (National Library of Albania)
-* https://bibliotekadigjitale.bksh.al/ (Digital Library of the National Library of Albania)
-* https://akt.gov.al/muze/ (Museums and archaeological resources of Albania)
-* https://iktk.gov.al/ (National Institute of Cultural Heritage)
-* https://institutialbanologjik.org/ (Albanological Institute of Prishtina)
-* https://ih-rks.org/ (Institute of History of Kosovo)
-* https://ashak.org/ (Academy of Sciences and Arts of Kosovo)
-* https://www.bk.rks-gov.net/ (National Library of Kosovo)
+- https://sq.wikipedia.org/wiki/Kultura_e_Shqip%C3%ABris%C3%AB
+- https://sq.wikipedia.org/wiki/Historia_e_Shqip%C3%ABris%C3%AB
+- http://www.akad.gov.al/ (Academy of Sciences of Albania)
+- http://www.bksh.al/ (National Library of Albania)
+- https://akt.gov.al/muze/ (Agency for Archaeological Services of Albania)
+- http://iktk.gov.al/ (National Institute of Cultural Heritage)
+- https://institutialbanologjik.org/ (Albanological Institute of Prishtina)
+- https://ih-rks.org/ (Institute of History of Kosovo)
+- https://ashak.org/ (Academy of Sciences and Arts of Kosovo)
+- https://www.bk.rks-gov.net/ (National Library of Kosovo)
+- https://bibliotekadigjitale.bksh.al/ (Digital Library of the National Library of Albania)
 
-Government — Albania:
+Government:
 
-* https://www.kryeministria.al/ (Office of the Prime Minister)
-* https://www.parlament.al/ (Parliament of Albania)
-* https://mod.gov.al/ (Ministry of Defense)
-* https://punetejashtme.gov.al/ (Ministry for Europe and Foreign Affairs)
-* https://financa.gov.al/ (Ministry of Finance)
-* https://bujqesia.gov.al/ (Ministry of Agriculture)
-* https://drejtesia.gov.al/ (Ministry of Justice)
-* https://shendetesia.gov.al/ (Ministry of Health)
-* https://kultura.gov.al/ (Ministry of Culture)
-* https://turizmi.gov.al/ (Ministry of Tourism)
-* https://arsimi.gov.al/ (Ministry of Education)
-* https://instat.gov.al/ (Institute of Statistics of Albania)
+- http://www.kryeministria.al/ (Kryeministria - Office of the Prime Minister)
+- https://www.parlament.al/ (Kuvendi i Shqipërisë - Parliament of Albania)
+- https://www.mod.gov.al/ (Ministria e Mbrojtjes - Ministry of Defense)
+- http://www.punetejashtme.gov.al/ (Ministria për Evropën dhe Punët e Jashtme - Ministry for Europe and Foreign Affairs)
+- http://www.financa.gov.al/ (Ministria e Financave dhe Ekonomisë - Ministry of Finance and Economy)
+- http://www.bujqesia.gov.al/ (Ministria e Bujqësisë dhe Zhvillimit Rural)
+- http://www.drejtesia.gov.al/ (Ministria e Drejtësisë - Ministry of Justice)
+- http://www.shendetesia.gov.al/ (Ministria e Shëndetësisë dhe Mbrojtjes Sociale)
+- http://www.kultura.gov.al/ (Ministria e Kulturës - Ministry of Culture)
+- http://turizmi.gov.al/ (Ministria e Turizmit dhe Mjedisit)
+- http://www.arsimi.gov.al/ (Ministria e Arsimit, Sportit dhe Rinisë)
+- https://kryeministri.rks-gov.net/ (Office of the Prime Minister / Government of Kosovo)
+- https://kuvendikosoves.org/ (Assembly of Kosovo)
+- https://gzk.rks-gov.net/ (Official Gazette of Kosovo)
+- https://ask.rks-gov.net/ (Kosovo Agency of Statistics)
+- https://president-ksgov.net/ (President of Kosovo)
 
-Government — Kosovo:
+Political Parties:
 
-* https://kryeministri.rks-gov.net/ (Office of the Prime Minister / Government of Kosovo)
-* https://kuvendikosoves.org/ (Assembly of Kosovo)
-* https://gzk.rks-gov.net/ (Official Gazette of Kosovo)
-* https://ask.rks-gov.net/ (Kosovo Agency of Statistics)
-* https://president-ksgov.net/ (President of Kosovo)
-* https://msh.rks-gov.net/ (Ministry of Health)
-* https://masht.rks-gov.net/ (Ministry of Education, Science, Technology and Innovation)
-* https://md.rks-gov.net/ (Ministry of Defense)
-* https://mpb.rks-gov.net/ (Ministry of Internal Affairs)
-* https://md.rks-gov.net/ (Ministry of Justice)
-* https://mfpt.rks-gov.net/ (Ministry of Finance)
-* https://me.rks-gov.net/ (Ministry of Economy)
-* https://mbpzhr.rks-gov.net/ (Ministry of Agriculture, Forestry and Rural Development)
-* https://mi.rks-gov.net/ (Ministry of Infrastructure)
-* https://mapl.rks-gov.net/ (Ministry of Local Government Administration)
-
-Political Parties — Albania:
-
-* https://ps.al/ (Socialist Party of Albania)
-* https://pd.al/ (Democratic Party of Albania)
-* https://psd.al/ (Social Democratic Party of Albania)
-* https://mundesia.al/ (Opportunity Party)
-* https://www.shqiperiabehet.al/ (Albania Becomes Movement)
-* https://levizjabashke.al/ (Lëvizja Bashkë)
-
-Political Parties — Kosovo:
-
-* https://www.vetevendosje.org/ (Lëvizja VETËVENDOSJE!)
-* https://pdk.info/ (Democratic Party of Kosovo)
-* https://lidhjademokratike.eu/ (Democratic League of Kosovo)
-* https://aak-ks.com/ (Alliance for the Future of Kosovo)
-* https://nisma.info/ (NISMA Socialdemokrate)
-* https://guxo.org/ (GUXO)
-
-Libraries / Archives / Digital Collections:
-
-* https://archive.org/details/booksbylanguage_albanian (Internet Archive — Books in Albanian)
-* https://bksh.al/ (National Library of Albania)
-* https://bibliotekadigjitale.bksh.al/ (Digital collections of the National Library of Albania)
-* https://www.bk.rks-gov.net/ (National Library of Kosovo)
-* https://institutialbanologjik.org/ (Albanological Institute — publications and digital archive)
-* https://ih-rks.org/ (Institute of History of Kosovo)
-* https://gzk.rks-gov.net/ (Official Gazette of Kosovo)
-* https://ask.rks-gov.net/ (Kosovo Agency of Statistics)
-* https://sq.wikipedia.org/ (Albanian Wikipedia)
-
-Academic / Research:
-
-* https://akad.gov.al/ (Academy of Sciences of Albania)
-* https://ashak.org/ (Academy of Sciences and Arts of Kosovo)
-* https://institutialbanologjik.org/ (Albanological Institute of Prishtina)
-* https://ih-rks.org/ (Institute of History of Kosovo)
-* https://uni-pr.edu/ (University of Prishtina)
-* https://unitir.edu.al/ (University of Tirana)
-* https://uniel.edu.al/ (University of Elbasan)
-* https://univlora.edu.al/ (University of Vlora)
-* https://unkorce.edu.al/ (University of Korça)
-
-Statistics / Data:
-
-* https://ask.rks-gov.net/ (Kosovo Agency of Statistics)
-* https://instat.gov.al/ (Institute of Statistics of Albania)
-* https://bankofalbania.org/ (Bank of Albania)
-* https://bqk-kos.org/ (Central Bank of the Republic of Kosovo)
-
-Culture / Museums / Heritage:
-
-* https://akt.gov.al/muze/ (Museums and archaeological resources of Albania)
-* https://iktk.gov.al/ (National Institute of Cultural Heritage)
-* https://bksh.al/ (National Library of Albania)
-* https://bibliotekadigjitale.bksh.al/ (Digital Library of Albania)
-* https://www.bk.rks-gov.net/ (National Library of Kosovo)
-* https://institutialbanologjik.org/ (Albanological Institute)
-* https://ih-rks.org/ (Institute of History of Kosovo)
-* https://ashak.org/ (Academy of Sciences and Arts of Kosovo)
-
-Universities:
-
-* https://uni-pr.edu/ (University of Prishtina)
-* https://unitir.edu.al/ (University of Tirana)
-* https://uniel.edu.al/ (University of Elbasan)
-* https://univlora.edu.al/ (University of Vlora)
-* https://unkorce.edu.al/ (University of Korça)
-
-Informative links (in English):
-
-* https://en.wikipedia.org/wiki/Albania
-* https://en.wikipedia.org/wiki/History_of_Albania
-* https://en.wikipedia.org/wiki/Albanian_language
-* https://en.wikipedia.org/wiki/Kosovo
-* https://en.wikipedia.org/wiki/History_of_Kosovo
-* https://albania.al/ (Official tourism information)
+- https://ps.al/ (Socialist Party of Albania)
+- https://pd.al/ (Democratic Party of Albania)
+- https://psd.al/ (Social Democratic Party of Albania)
+- https://mundesia.al/ (Opportunity Party)
+- https://www.shqiperiabehet.al/ (Albania Becomes Movement)
+- https://levizjabashke.al/ (Lëvizja Bashkë)
+- https://www.vetevendosje.org/ (Lëvizja VETËVENDOSJE!)
+- https://pdk.info/ (Democratic Party of Kosovo)
+- https://lidhjademokratike.eu/ (Democratic League of Kosovo)
+- https://aak-ks.com/ (Alliance for the Future of Kosovo)
 
 Other:
 
-* https://sq.wikipedia.org/ (Albanian Wikipedia)
-* https://archive.org/details/booksbylanguage_albanian (Internet Archive — Books in Albanian)
-* https://bibliotekadigjitale.bksh.al/ (Albanian digital library)
+- https://sq.wikipedia.org
+- https://archive.org/details/booksbylanguage_albanian (Internet Archive — Books in Albanian)
+
+Informative links (in English):
+
+- https://en.wikipedia.org/wiki/Albania
+- https://en.wikipedia.org/wiki/History_of_Albania
+- https://en.wikipedia.org/wiki/Albanian_language
+- https://albania.al/ (Official website of the National Tourism Agency)
 
 Additional Information:
 
-* ISO-639-3 code: sqi
-* https://en.wikipedia.org/wiki/ISO_639:sqi
-* Albanian is a living Indo-European language.
-* Albania and Kosovo are major geographic centers of Albanian-language publishing, education, government documentation, journalism, culture, research, and digital content.
-* This document includes Albanian-language web resources from both Albania and Kosovo.
-* The resources include news, government publications, political organizations, universities, scientific research, statistics, libraries, archives, books, cultural heritage, museums, historical documents, and other long-form Albanian-language content.
-* Digital libraries and archival collections are included to improve the representation of historical and long-form Albanian-language material.
-* This document needs reviewing by a native speaker.
+- ISO-639-3 code: sqi
+- https://en.wikipedia.org/wiki/ISO_639:sqi
+- This document needs reviewing by a native speaker.
 
-Scripts:
+## Scripts:
 
 Thank you to these people who have helped create this document:
 
-* [Ethan Wenokur](https://github.com/e-Winnie)
+- [Ethan Wenokur](https://github.com/e-Winnie)
+
+## Instructions
+
+There are 2 ways to add to this document. If you aren't very familiar with Github, you can copy the entire document into an email, fill it out, and send it to web-languages ZAT commoncrawl ZOT org. We'll do the rest.
+
+If you are familiar with Github, and are logged in, click on the pen icon in the upper right corner to start editing the document. Github will request that you fork the repo. Do that, edit the document, and finally create a pull request.
+
+To see a partially completed example, look at the [Welsh](https://github.com/commoncrawl/web-languages/blob/main/living/welsh.md) entry.
+
+Sometimes asking a Large Language Model can be helpful: "What are some top websites written in the Welsh language?"
+
+## What kind of websites are you looking for?
+
+If you look at the template, we have requested urls in a few categories: News, Culture/History, Government, Political Parties, and Other. Remember that we're looking for websites in this particular language. If the language is only a part of the website, and that's visible in the URL as https://example.com/catalan/, then that's the URL you should add.
+
+For a language like Hindi, with 500 million speakers, there are a lot of websites to choose from. Please suggest websites that are important and influential, and please think about diversity. Are all geographic regions represented?
+
+For a country-wide language like Hungarian, there are still probably a wide variety of websites to choose from. If a website is all English, however, that's not what we're looking for.
+
+For a regional language like Catalan, things are trickier. Catalan has multiple names -- it's called Valencian in some parts of Spain -- and use of the Catalan language is a part of a vigorous debate in Spanish national and regional politics. You might not be able to find Catalan-language content for every political party, and government websites might offer Catalan content one day and remove it after the next election. In that case, please do the best you can.
+
+If your favorite language has its own Wikipedia -- check the list here -- please include this link under "Other".
+
+## License
+
+This work is marked with [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+By editing this file, contributors are agreeing to release their contributions under the CC0 license.

--- a/living/albanian.md
+++ b/living/albanian.md
@@ -9,43 +9,24 @@ Additional names:
 News:
 
 * https://top-channel.tv/ (Top Channel)
-
 * https://tvklan.al/ (TV Klan)
-
 * https://www.panorama.com.al/ (Panorama)
-
 * https://shqiptarja.com/ (Shqiptarja)
-
 * https://balkanweb.com/ (BalkanWeb)
-
 * https://www.gazetatema.net/ (Gazeta Tema)
-
 * https://www.oranews.tv/ (Ora News)
-
 * https://lapsi.al/ (Analysis and investigative journalism)
-
 * https://www.newsbomb.al/ (News)
-
 * https://ata.gov.al/ (Albanian Telegraphic Agency)
-
 * https://sq.wikipedia.org/ (Albanian Wikipedia)
-
 * https://rtklive.com/ (Radio Television of Kosovo)
-
 * https://kallxo.com/ (Investigative journalism and news)
-
 * https://telegrafi.com/ (Albanian-language news)
-
 * https://koha.net/ (Albanian-language news, culture and archive)
-
 * https://gazetaexpress.com/ (Albanian-language news)
-
 * https://insajderi.org/ (Investigative journalism)
-
 * https://zeri.info/ (Albanian-language news)
-
 * https://kosovapress.com/ (Kosovo Press)
-
 * https://ekonomiaonline.com/ (Economy and news)
 
 Culture / History:
@@ -80,33 +61,19 @@ Government — Albania:
 Government — Kosovo:
 
 * https://kryeministri.rks-gov.net/ (Office of the Prime Minister / Government of Kosovo)
-
 * https://kuvendikosoves.org/ (Assembly of Kosovo)
-
 * https://gzk.rks-gov.net/ (Official Gazette of Kosovo)
-
 * https://ask.rks-gov.net/ (Kosovo Agency of Statistics)
-
 * https://president-ksgov.net/ (President of Kosovo)
-
 * https://msh.rks-gov.net/ (Ministry of Health)
-
 * https://masht.rks-gov.net/ (Ministry of Education, Science, Technology and Innovation)
-
 * https://md.rks-gov.net/ (Ministry of Defense)
-
 * https://mpb.rks-gov.net/ (Ministry of Internal Affairs)
-
 * https://md.rks-gov.net/ (Ministry of Justice)
-
 * https://mfpt.rks-gov.net/ (Ministry of Finance)
-
 * https://me.rks-gov.net/ (Ministry of Economy)
-
 * https://mbpzhr.rks-gov.net/ (Ministry of Agriculture, Forestry and Rural Development)
-
 * https://mi.rks-gov.net/ (Ministry of Infrastructure)
-
 * https://mapl.rks-gov.net/ (Ministry of Local Government Administration)
 
 Political Parties — Albania:
@@ -206,6 +173,5 @@ Additional Information:
 Scripts:
 
 Thank you to these people who have helped create this document:
-*
 
 * [Ethan Wenokur](https://github.com/e-Winnie)

--- a/living/albanian.md
+++ b/living/albanian.md
@@ -1,122 +1,211 @@
 # Web Language: Albanian
 
 Additional names:
-- shqip
-- 
+
+* shqip
+* gjuha shqipe
+* Albanian language
 
 News:
-- https://top-channel.tv/
-- https://tvklan.al/
-- https://www.panorama.com.al/
-- https://shqiptarja.com/
-- https://balkanweb.com/
-- https://www.gazetatema.net/
-- https://www.oranews.tv/
-- https://lapsi.al/ (Analysis and investigative journalism)
-- https://www.newsbomb.al/
-- https://ata.gov.al/ (National Broadcaster)
+
+* https://top-channel.tv/ (Top Channel)
+
+* https://tvklan.al/ (TV Klan)
+
+* https://www.panorama.com.al/ (Panorama)
+
+* https://shqiptarja.com/ (Shqiptarja)
+
+* https://balkanweb.com/ (BalkanWeb)
+
+* https://www.gazetatema.net/ (Gazeta Tema)
+
+* https://www.oranews.tv/ (Ora News)
+
+* https://lapsi.al/ (Analysis and investigative journalism)
+
+* https://www.newsbomb.al/ (News)
+
+* https://ata.gov.al/ (Albanian Telegraphic Agency)
+
+* https://sq.wikipedia.org/ (Albanian Wikipedia)
+
+* https://rtklive.com/ (Radio Television of Kosovo)
+
+* https://kallxo.com/ (Investigative journalism and news)
+
+* https://telegrafi.com/ (Albanian-language news)
+
+* https://koha.net/ (Albanian-language news, culture and archive)
+
+* https://gazetaexpress.com/ (Albanian-language news)
+
+* https://insajderi.org/ (Investigative journalism)
+
+* https://zeri.info/ (Albanian-language news)
+
+* https://kosovapress.com/ (Kosovo Press)
+
+* https://ekonomiaonline.com/ (Economy and news)
 
 Culture / History:
-- https://sq.wikipedia.org/wiki/Kultura_e_Shqip%C3%ABris%C3%AB
-- https://sq.wikipedia.org/wiki/Historia_e_Shqip%C3%ABris%C3%AB
-- http://www.akad.gov.al/ (Academy of Sciences of Albania)
-- http://www.bksh.al/ (National Library of Albania)
-- https://akt.gov.al/muze/ (Agency for Archaeological Services of Albania)
-- http://iktk.gov.al/ (National Institute of Cultural Heritage)
 
-Government:
-- http://www.kryeministria.al/ (Kryeministria - Office of the Prime Minister)
-- https://www.parlament.al/ (Kuvendi i Shqipërisë - Parliament of Albania)
-- https://www.mod.gov.al/ (Ministria e Mbrojtjes - Ministry of Defense)
-- http://www.punetejashtme.gov.al/ (Ministria për Evropën dhe Punët e Jashtme - Ministry for Europe and Foreign Affairs)
-- http://www.financa.gov.al/ (Ministria e Financave dhe Ekonomisë - Ministry of Finance and Economy)
-- http://www.bujqesia.gov.al/ (Ministria e Bujqësisë dhe Zhvillimit Rural - Ministry of Agriculture and Rural Development)
-- http://www.drejtesia.gov.al/ (Ministria e Drejtësisë - Ministry of Justice)
-- http://www.shendetesia.gov.al/ (Ministria e Shëndetësisë dhe Mbrojtjes Sociale - Ministry of Health and Social Protection)
-- http://www.kultura.gov.al/ (Ministria e Kulturës - Ministry of Culture)
-- http://turizmi.gov.al/ (Ministria e Turizmit dhe Mjedisit - Ministry of Tourism and Environment)
-- http://www.arsimi.gov.al/ (Ministria e Arsimit, Sportit dhe Rinisë - Ministry of Education, Sports and Youth)
+* https://sq.wikipedia.org/wiki/Kultura_e_Shqip%C3%ABris%C3%AB
+* https://sq.wikipedia.org/wiki/Historia_e_Shqip%C3%ABris%C3%AB
+* https://akad.gov.al/ (Academy of Sciences of Albania)
+* https://bksh.al/ (National Library of Albania)
+* https://bibliotekadigjitale.bksh.al/ (Digital Library of the National Library of Albania)
+* https://akt.gov.al/muze/ (Museums and archaeological resources of Albania)
+* https://iktk.gov.al/ (National Institute of Cultural Heritage)
+* https://institutialbanologjik.org/ (Albanological Institute of Prishtina)
+* https://ih-rks.org/ (Institute of History of Kosovo)
+* https://ashak.org/ (Academy of Sciences and Arts of Kosovo)
+* https://www.bk.rks-gov.net/ (National Library of Kosovo)
 
-Political Parties:
-- https://ps.al/ (Socialist Party of Albania)
-- https://pd.al/ (Democratic Party of Albania)
-- https://psd.al/ (Social Democratic Party of Albania)
-- https://mundesia.al/ (Opportunity Party)
-- https://www.shqiperiabehet.al/ (Albania Becomes Movement)
-- https://levizjabashke.al/ (Lëvizja Bashkë)
+Government — Albania:
 
-Other:
-- https://sq.wikipedia.org
-- 
-- 
+* https://www.kryeministria.al/ (Office of the Prime Minister)
+* https://www.parlament.al/ (Parliament of Albania)
+* https://mod.gov.al/ (Ministry of Defense)
+* https://punetejashtme.gov.al/ (Ministry for Europe and Foreign Affairs)
+* https://financa.gov.al/ (Ministry of Finance)
+* https://bujqesia.gov.al/ (Ministry of Agriculture)
+* https://drejtesia.gov.al/ (Ministry of Justice)
+* https://shendetesia.gov.al/ (Ministry of Health)
+* https://kultura.gov.al/ (Ministry of Culture)
+* https://turizmi.gov.al/ (Ministry of Tourism)
+* https://arsimi.gov.al/ (Ministry of Education)
+* https://instat.gov.al/ (Institute of Statistics of Albania)
+
+Government — Kosovo:
+
+* https://kryeministri.rks-gov.net/ (Office of the Prime Minister / Government of Kosovo)
+
+* https://kuvendikosoves.org/ (Assembly of Kosovo)
+
+* https://gzk.rks-gov.net/ (Official Gazette of Kosovo)
+
+* https://ask.rks-gov.net/ (Kosovo Agency of Statistics)
+
+* https://president-ksgov.net/ (President of Kosovo)
+
+* https://msh.rks-gov.net/ (Ministry of Health)
+
+* https://masht.rks-gov.net/ (Ministry of Education, Science, Technology and Innovation)
+
+* https://md.rks-gov.net/ (Ministry of Defense)
+
+* https://mpb.rks-gov.net/ (Ministry of Internal Affairs)
+
+* https://md.rks-gov.net/ (Ministry of Justice)
+
+* https://mfpt.rks-gov.net/ (Ministry of Finance)
+
+* https://me.rks-gov.net/ (Ministry of Economy)
+
+* https://mbpzhr.rks-gov.net/ (Ministry of Agriculture, Forestry and Rural Development)
+
+* https://mi.rks-gov.net/ (Ministry of Infrastructure)
+
+* https://mapl.rks-gov.net/ (Ministry of Local Government Administration)
+
+Political Parties — Albania:
+
+* https://ps.al/ (Socialist Party of Albania)
+* https://pd.al/ (Democratic Party of Albania)
+* https://psd.al/ (Social Democratic Party of Albania)
+* https://mundesia.al/ (Opportunity Party)
+* https://www.shqiperiabehet.al/ (Albania Becomes Movement)
+* https://levizjabashke.al/ (Lëvizja Bashkë)
+
+Political Parties — Kosovo:
+
+* https://www.vetevendosje.org/ (Lëvizja VETËVENDOSJE!)
+* https://pdk.info/ (Democratic Party of Kosovo)
+* https://lidhjademokratike.eu/ (Democratic League of Kosovo)
+* https://aak-ks.com/ (Alliance for the Future of Kosovo)
+* https://nisma.info/ (NISMA Socialdemokrate)
+* https://guxo.org/ (GUXO)
+
+Libraries / Archives / Digital Collections:
+
+* https://archive.org/details/booksbylanguage_albanian (Internet Archive — Books in Albanian)
+* https://bksh.al/ (National Library of Albania)
+* https://bibliotekadigjitale.bksh.al/ (Digital collections of the National Library of Albania)
+* https://www.bk.rks-gov.net/ (National Library of Kosovo)
+* https://institutialbanologjik.org/ (Albanological Institute — publications and digital archive)
+* https://ih-rks.org/ (Institute of History of Kosovo)
+* https://gzk.rks-gov.net/ (Official Gazette of Kosovo)
+* https://ask.rks-gov.net/ (Kosovo Agency of Statistics)
+* https://sq.wikipedia.org/ (Albanian Wikipedia)
+
+Academic / Research:
+
+* https://akad.gov.al/ (Academy of Sciences of Albania)
+* https://ashak.org/ (Academy of Sciences and Arts of Kosovo)
+* https://institutialbanologjik.org/ (Albanological Institute of Prishtina)
+* https://ih-rks.org/ (Institute of History of Kosovo)
+* https://uni-pr.edu/ (University of Prishtina)
+* https://unitir.edu.al/ (University of Tirana)
+* https://uniel.edu.al/ (University of Elbasan)
+* https://univlora.edu.al/ (University of Vlora)
+* https://unkorce.edu.al/ (University of Korça)
+
+Statistics / Data:
+
+* https://ask.rks-gov.net/ (Kosovo Agency of Statistics)
+* https://instat.gov.al/ (Institute of Statistics of Albania)
+* https://bankofalbania.org/ (Bank of Albania)
+* https://bqk-kos.org/ (Central Bank of the Republic of Kosovo)
+
+Culture / Museums / Heritage:
+
+* https://akt.gov.al/muze/ (Museums and archaeological resources of Albania)
+* https://iktk.gov.al/ (National Institute of Cultural Heritage)
+* https://bksh.al/ (National Library of Albania)
+* https://bibliotekadigjitale.bksh.al/ (Digital Library of Albania)
+* https://www.bk.rks-gov.net/ (National Library of Kosovo)
+* https://institutialbanologjik.org/ (Albanological Institute)
+* https://ih-rks.org/ (Institute of History of Kosovo)
+* https://ashak.org/ (Academy of Sciences and Arts of Kosovo)
+
+Universities:
+
+* https://uni-pr.edu/ (University of Prishtina)
+* https://unitir.edu.al/ (University of Tirana)
+* https://uniel.edu.al/ (University of Elbasan)
+* https://univlora.edu.al/ (University of Vlora)
+* https://unkorce.edu.al/ (University of Korça)
 
 Informative links (in English):
-- https://en.wikipedia.org/wiki/Albania
-- https://en.wikipedia.org/wiki/History_of_Albania
-- https://en.wikipedia.org/wiki/Albanian_language
-- https://albania.al/ (Official website of the National Tourism Agency)
+
+* https://en.wikipedia.org/wiki/Albania
+* https://en.wikipedia.org/wiki/History_of_Albania
+* https://en.wikipedia.org/wiki/Albanian_language
+* https://en.wikipedia.org/wiki/Kosovo
+* https://en.wikipedia.org/wiki/History_of_Kosovo
+* https://albania.al/ (Official tourism information)
+
+Other:
+
+* https://sq.wikipedia.org/ (Albanian Wikipedia)
+* https://archive.org/details/booksbylanguage_albanian (Internet Archive — Books in Albanian)
+* https://bibliotekadigjitale.bksh.al/ (Albanian digital library)
 
 Additional Information:
-- ISO-639-3 code: sqi
-- https://en.wikipedia.org/wiki/ISO_639:sqi
-- This document needs reviewing by a native speaker.
 
+* ISO-639-3 code: sqi
+* https://en.wikipedia.org/wiki/ISO_639:sqi
+* Albanian is a living Indo-European language.
+* Albania and Kosovo are major geographic centers of Albanian-language publishing, education, government documentation, journalism, culture, research, and digital content.
+* This document includes Albanian-language web resources from both Albania and Kosovo.
+* The resources include news, government publications, political organizations, universities, scientific research, statistics, libraries, archives, books, cultural heritage, museums, historical documents, and other long-form Albanian-language content.
+* Digital libraries and archival collections are included to improve the representation of historical and long-form Albanian-language material.
+* This document needs reviewing by a native speaker.
 
 Scripts:
-- 
 
 Thank you to these people who have helped create this document:
-- [Ethan Wenokur](https://github.com/e-Winnie)
-- 
+*
 
-## Instructions
-
-There are 2 ways to add to this document. If you aren't very familiar
-with Github, you can copy the entire document into an email, fill it
-out, and send it to web-languages ZAT commoncrawl ZOT org. We'll do the rest.
-
-If you are familiar with Github, and are logged in, click on the pen
-icon in the upper right corner to start editing the document.
-Github will request that you fork the repo. Do that, edit the
-document, and finally create a pull request.
-
-To see a partially completed example, look at the
-[Welsh](../living/welsh.md) entry.
-
-Sometimes asking a Large Language Model can be helpful: "What are some
-top websites written in the Welsh language?"
-
-## What kind of websites are you looking for?
-
-If you look at the template, we have requested urls in a few
-categories: News, Culture/History, Government, Political Parties, and
-Other. Remember that we're looking for websites in this particular
-language. If the language is only a part of the website, and that's
-visible in the URL as https://example.com/catalan/, then that's the
-URL you should add.
-
-For a language like Hindi, with 500 million speakers, there are a lot
-of websites to choose from. Please suggest websites that are important
-and influential, and please think about diversity. Are all geographic
-regions represented?
-
-For a country-wide language like Hungarian, there are still probably a
-wide variety of websites to choose from. If a website is all English,
-however, that's not what we're looking for.
-
-For a regional language like Catalan, things are trickier. Catalan has
-multiple names -- it's called Valencian in some parts of Spain -- and
-use of the Catalan language is a part of a vigorous debate in Spanish
-national and regional politics. You might not be able to find
-Catalan-language content for every political party, and government
-websites might offer Catalan content one day and remove it after
-the next election. In that case, please do the best you can.
-
-If your favorite language has its own Wikipedia -- [check the list here](https://en.wikipedia.org/wiki/List_of_Wikipedias) --
-please include this link under "Other".
-
-## License
-
-<p xmlns:cc="http://creativecommons.org/ns#" >This work is marked with <a href="https://creativecommons.org/publicdomain/zero/1.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">CC0 1.0<img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1" alt=""><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/zero.svg?ref=chooser-v1" alt=""></a></p>
-
-By editing this file, contributers are agreeing to release their contributions under the CC0 license.
+* [Ethan Wenokur](https://github.com/e-Winnie)


### PR DESCRIPTION
## Summary

This pull request expands the Albanian web language resource list with additional Albanian-language sources from both Albania and Kosovo.

The additions include:

- Albanian and Kosovo news sources
- Government and parliamentary websites
- Official Gazette and statistical institutions
- Political parties
- National libraries and digital libraries
- Albanological and historical institutes
- Universities and academic institutions
- Cultural heritage and museum resources
- Albanian books and archival collections on Internet Archive

The goal is to improve geographic and topical coverage of Albanian-language web content and help Common Crawl discover additional Albanian-language sources.

The list includes resources from both Albania and Kosovo because they are major geographic centers of Albanian-language publishing and web content.

ISO-639-3: sqi